### PR TITLE
fix(ci): use standard checkout for deploy job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,7 +145,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: "latest"
-      - uses: 'namespacelabs/nscloud-checkout-action@v8'
+      - uses: 'actions/checkout@v6'
         with:
           fetch-depth: 0
       - name: Tailscale


### PR DESCRIPTION
## Summary
- replace `namespacelabs/nscloud-checkout-action@v8` with `actions/checkout@v6` in the `Deploy` job
- keep Namespace checkout on jobs that run on Namespace runners

## Why
The failing deploy job runs on `ubuntu-24.04`, but `nscloud-checkout-action@v8` requires Namespace Git caching labels. The job fails before Tailscale/deploy starts.

Failing job: https://github.com/formancehq/agent/actions/runs/26295832012/job/77408618129

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/main.yml"); puts "yaml ok"'`\n\n`actionlint` is not installed locally.