### PR TITLE
fix: update CODEOWNERS team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @formancehq/backend
+* @formancehq/engineer


### PR DESCRIPTION
## Summary

- replace the removed `@formancehq/backend` CODEOWNER with `@formancehq/engineer`
- preserve repository-wide ownership coverage

## Validation

- `git diff --check`
- confirmed the `engineer` organization team exists